### PR TITLE
Fix missing packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ export BUSYBOX_VERSION=1.34.1
 #
 echo "[+] Checking / installing dependencies..."
 sudo apt-get -q update
-sudo apt-get -q install -y bison flex libelf-dev cpio build-essential libssl-dev qemu-system-x86
+sudo apt-get -q install -y bc bison flex libelf-dev cpio build-essential libssl-dev qemu-system-x86 wget
 
 #
 # linux kernel


### PR DESCRIPTION
Build with binding the
directory inside an Ubuntu container.

```
sudo docker run -it --rm -v "$PWD":/build:rw --workdir /build ubuntu:20.04 ./build.sh
```